### PR TITLE
Add slot-based attribute distribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,12 +219,30 @@
       <label>Stat:<select id="stat"></select></label>
       <label style="margin-top:0.6em;"><input id="useAllSlots" type="checkbox" checked> Use all slots</label>
       <div id="slotConfig" style="display:none;margin-top:.6em;">
-        <label>Slot 1:<select id="slot1" class="slot-select"></select></label>
-        <label>Slot 2:<select id="slot2" class="slot-select"></select></label>
-        <label>Slot 3:<select id="slot3" class="slot-select"></select></label>
-        <label>Slot 4:<select id="slot4" class="slot-select"></select></label>
-        <label>Slot 5:<select id="slot5" class="slot-select"></select></label>
-        <label>Slot 6:<select id="slot6" class="slot-select"></select></label>
+        <label>Slot 1:
+          <select id="slot1" class="slot-select"></select>
+          <input id="weight1" class="slot-weight" type="number" min="0" value="20" style="width:4em" />%
+        </label>
+        <label>Slot 2:
+          <select id="slot2" class="slot-select"></select>
+          <input id="weight2" class="slot-weight" type="number" min="0" value="20" style="width:4em" />%
+        </label>
+        <label>Slot 3:
+          <select id="slot3" class="slot-select"></select>
+          <input id="weight3" class="slot-weight" type="number" min="0" value="20" style="width:4em" />%
+        </label>
+        <label>Slot 4:
+          <select id="slot4" class="slot-select"></select>
+          <input id="weight4" class="slot-weight" type="number" min="0" value="20" style="width:4em" />%
+        </label>
+        <label>Slot 5:
+          <select id="slot5" class="slot-select"></select>
+          <input id="weight5" class="slot-weight" type="number" min="0" value="20" style="width:4em" />%
+        </label>
+        <label>Slot 6:
+          <select id="slot6" class="slot-select"></select>
+          <input id="weight6" class="slot-weight" type="number" min="0" value="20" style="width:4em" />%
+        </label>
       </div>
       <div id="baseStats-label" style="display:none;">
         <label>Base Health: <input id="baseHealth" type="number" min="0" value="250"></label>

--- a/index.html
+++ b/index.html
@@ -217,6 +217,15 @@
       <label>Number of Items:<input id="maxItems" type="number" min="1" max="6" value="5"></label>
       <label>Hero:<select id="hero"></select></label>
       <label>Stat:<select id="stat"></select></label>
+      <label style="margin-top:0.6em;"><input id="useAllSlots" type="checkbox" checked> Use all slots</label>
+      <div id="slotConfig" style="display:none;margin-top:.6em;">
+        <label>Slot 1:<select id="slot1" class="slot-select"></select></label>
+        <label>Slot 2:<select id="slot2" class="slot-select"></select></label>
+        <label>Slot 3:<select id="slot3" class="slot-select"></select></label>
+        <label>Slot 4:<select id="slot4" class="slot-select"></select></label>
+        <label>Slot 5:<select id="slot5" class="slot-select"></select></label>
+        <label>Slot 6:<select id="slot6" class="slot-select"></select></label>
+      </div>
       <div id="baseStats-label" style="display:none;">
         <label>Base Health: <input id="baseHealth" type="number" min="0" value="250"></label>
         <label>Base Shield: <input id="baseShield" type="number" min="0" value="250"></label>

--- a/js/main.js
+++ b/js/main.js
@@ -29,24 +29,44 @@ function doCalculate() {
   const baseA = CONSTANTS.HP_STATS.includes(stat) || stat === CONSTANTS.HIT_POINT_STAT 
     ? parseInt(document.getElementById('baseArmor').value, 10) : 0;
   const maxItems = Math.min(Math.max(parseInt(document.getElementById('maxItems').value, 10) || 5, 1), CONSTANTS.MAX_ITEMS);
+  const useAll = document.getElementById('useAllSlots').checked;
+
+  const slotStats = [];
+  if (!useAll) {
+    for (let i = 1; i <= 6; i++) {
+      const val = document.getElementById('slot' + i).value;
+      slotStats.push(val === 'main' ? stat : val);
+    }
+  }
   
   // Calculate available cash after reserves
   const availableCash = Math.max(0, cash - totalReserve);
   
-  // Perform calculation
-  const result = calcFns.search({
-    items: state.items, 
-    cash: availableCash, 
-    hero, 
-    stat, 
-    baseH, 
-    baseS, 
-    baseA, 
-    maxItems
-  });
-  
-  // Render results
-  ui.renderResults(result, { stat, baseH, baseS, baseA, totalReserve });
+  let result;
+  if (useAll) {
+    result = calcFns.search({
+      items: state.items,
+      cash: availableCash,
+      hero,
+      stat,
+      baseH,
+      baseS,
+      baseA,
+      maxItems: 6
+    });
+    ui.renderResults(result, { stat, baseH, baseS, baseA, totalReserve, hero });
+  } else {
+    result = calcFns.searchMulti({
+      items: state.items,
+      cash: availableCash,
+      hero,
+      stats: slotStats,
+      baseH,
+      baseS,
+      baseA
+    });
+    ui.renderMultiStatResults(result, { baseH, baseS, baseA, hero });
+  }
 }
 
 // Data loading
@@ -79,7 +99,13 @@ document.getElementById('calculate').addEventListener('click', doCalculate);
 document.getElementById('cash').addEventListener('keydown', e => {
   if (e.key === "Enter") doCalculate();
 });
-document.getElementById('stat').addEventListener('change', ui.showBaseHPIfNeeded);
+document.getElementById('stat').addEventListener('change', () => {
+  ui.showBaseHPIfNeeded();
+  ui.populateSlotSelectors();
+});
+document.getElementById('useAllSlots').addEventListener('change', () => {
+  document.getElementById('slotConfig').style.display = document.getElementById('useAllSlots').checked ? 'none' : '';
+});
 
 // Initialize the app
 loadData();

--- a/js/main.js
+++ b/js/main.js
@@ -31,11 +31,12 @@ function doCalculate() {
   const maxItems = Math.min(Math.max(parseInt(document.getElementById('maxItems').value, 10) || 5, 1), CONSTANTS.MAX_ITEMS);
   const useAll = document.getElementById('useAllSlots').checked;
 
-  const slotStats = [];
+  const slotConfig = [];
   if (!useAll) {
     for (let i = 1; i <= 6; i++) {
       const val = document.getElementById('slot' + i).value;
-      slotStats.push(val === 'main' ? stat : val);
+      const weight = parseFloat(document.getElementById('weight' + i).value) || 0;
+      slotConfig.push({ stat: val === 'main' ? stat : val, weight });
     }
   }
   
@@ -56,11 +57,11 @@ function doCalculate() {
     });
     ui.renderResults(result, { stat, baseH, baseS, baseA, totalReserve, hero });
   } else {
-    result = calcFns.searchMulti({
+    result = calcFns.searchWeighted({
       items: state.items,
       cash: availableCash,
       hero,
-      stats: slotStats,
+      slots: slotConfig,
       baseH,
       baseS,
       baseA

--- a/js/ui.js
+++ b/js/ui.js
@@ -16,6 +16,7 @@ export const ui = {
     
     select.disabled = !stats.length;
     ui.showBaseHPIfNeeded();
+    ui.populateSlotSelectors();
   },
   
   populateHeroes: () => {
@@ -32,149 +33,184 @@ export const ui = {
   
   showBaseHPIfNeeded: () => {
     const stat = document.getElementById('stat').value;
-    document.getElementById('baseStats-label').style.display = 
+    document.getElementById('baseStats-label').style.display =
       CONSTANTS.HP_STATS.includes(stat) || stat === CONSTANTS.HIT_POINT_STAT ? "" : "none";
   },
-  
-  renderResults: (result, params) => {
-    const { stat, baseH, baseS, baseA, totalReserve } = params;
+
+  populateSlotSelectors: () => {
+    const mainStat = document.getElementById('stat').value;
+    const selects = document.querySelectorAll('.slot-select');
+    const stats = Array.from(document.getElementById('stat').options).map(o => o.value);
+    selects.forEach(sel => {
+      const prev = sel.value;
+      sel.innerHTML = '';
+      const optMain = document.createElement('option');
+      optMain.value = 'main';
+      optMain.textContent = `Use main selection (${CONSTANTS.STAT_DISPLAY_NAMES[mainStat] || mainStat})`;
+      sel.appendChild(optMain);
+      stats.forEach(stat => {
+        const op = document.createElement('option');
+        op.value = stat;
+        op.textContent = CONSTANTS.STAT_DISPLAY_NAMES[stat] || stat;
+        sel.appendChild(op);
+      });
+      sel.value = Array.from(sel.options).some(o => o.value === prev) ? prev : 'main';
+    });
+  },
+
+  renderResultString: (result, params) => {
+    const { stat, baseH, baseS, baseA, hero } = params;
     const { HIT_POINT_STAT, WEAPON_EFFECT_STAT, HP_STATS, STAT_DISPLAY_NAMES } = CONSTANTS;
-    
+
     const statLabel = STAT_DISPLAY_NAMES[stat] || stat;
-    let html = "";
-    
+    let html = '';
+
     if (stat === HIT_POINT_STAT) {
       html = `
-        <div>Max <b>${statLabel}</b> achievable: <span style="color: #2196f3">+${util.roundInt(result.max)}</span> 
-          (Total: <b>${util.roundInt(result.total)}</b>, base: ${util.roundInt(baseH + baseS + baseA)}, 
+        <div>Max <b>${statLabel}</b> achievable: <span style="color: #2196f3">+${util.roundInt(result.max)}</span>
+          (Total: <b>${util.roundInt(result.total)}</b>, base: ${util.roundInt(baseH + baseS + baseA)},
           <span style="color:#4db6ac">${result.bestCost || 0} cash</span>)
         </div>
-        <div>Breakdown: 
-          <span style="color:#2196f3">Health</span> <b>${util.roundInt(result.perType.Health.total)}</b> + 
-          <span style="color:#a020cf">Armor</span> <b>${util.roundInt(result.perType.Armor.total)}</b> + 
+        <div>Breakdown:
+          <span style="color:#2196f3">Health</span> <b>${util.roundInt(result.perType.Health.total)}</b> +
+          <span style="color:#a020cf">Armor</span> <b>${util.roundInt(result.perType.Armor.total)}</b> +
           <span style="color:#20baa2">Shield</span> <b>${util.roundInt(result.perType.Shield.total)}</b>
         </div>
       `;
     } else if (stat === WEAPON_EFFECT_STAT) {
       const percentIncrease = ((result.max - 1) * 100).toFixed(2);
       html = `
-        <div>Max <b>${statLabel}</b> achievable: <span style="color:#20baa2">+${percentIncrease}%</span> 
+        <div>Max <b>${statLabel}</b> achievable: <span style="color:#20baa2">+${percentIncrease}%</span>
           (WP: +${result.wp}%, AS: +${result.as}%, <span style="color:#4db6ac">${result.bestCost || 0} cash</span>)
         </div>
       `;
     } else if (HP_STATS.includes(stat)) {
-      const baseValue = stat === "Health" ? baseH : stat === "Shield" ? baseS : baseA;
+      const baseValue = stat === 'Health' ? baseH : stat === 'Shield' ? baseS : baseA;
       html = `
-        <div>Max <b>${statLabel}</b> achievable: <span style="color:#2196f3">+${util.roundInt(result.max)}</span> 
-          (Total: <b>${util.roundInt(result.total)}</b>, base: ${util.roundInt(baseValue)}, 
+        <div>Max <b>${statLabel}</b> achievable: <span style="color:#2196f3">+${util.roundInt(result.max)}</span>
+          (Total: <b>${util.roundInt(result.total)}</b>, base: ${util.roundInt(baseValue)},
           <span style="color:#4db6ac">${result.bestCost || 0} cash</span>)
         </div>
       `;
     } else {
       html = `
-        <div>Max <b>${statLabel}</b> achievable: <span style="color:#20baa2">${result.max}%</span> 
+        <div>Max <b>${statLabel}</b> achievable: <span style="color:#20baa2">${result.max}%</span>
           (<span style="color:#4db6ac">${result.bestCost || 0} cash</span>)
         </div>
       `;
     }
-    
+
     if (result.picked.length) {
       html += `<div class="item-list"><b>Picked items:</b><ul>`;
-      
+
       result.picked.forEach(item => {
         const priceClass = util.getPriceClass(item.cost);
-        let statValue = "";
-        
+        let statValue = '';
+
         if (stat === HIT_POINT_STAT) {
           const statParts = [];
-          
+
           HP_STATS.forEach(hpStat => {
             let flat = 0, percent = 0;
-            
+
             item.attributes?.forEach(attr => {
               if (attr.type === hpStat) {
-                if (typeof attr.value === "string" && attr.value.endsWith("%")) {
+                if (typeof attr.value === 'string' && attr.value.endsWith('%')) {
                   percent += util.parsePercent(attr.value);
                 } else {
                   flat += (+attr.value || 0);
                 }
               }
             });
-            
+
             if (flat) statParts.push(`${hpStat}: +${flat}`);
             if (percent) statParts.push(`${hpStat}: +${percent}%`);
           });
-          
-          statValue = statParts.join(" | ");
+
+          statValue = statParts.join(' | ');
         } else if (stat === WEAPON_EFFECT_STAT) {
           let wp = 0, as = 0;
-          
-          if (params.hero === "Ashe") {
-            if (item.name?.toUpperCase() === "TRIPOD") wp += 13;
-            if (item.name?.toUpperCase() === "IRONSIGHTS") wp += 20;
+
+          if (hero === 'Ashe') {
+            if (item.name?.toUpperCase() === 'TRIPOD') wp += 13;
+            if (item.name?.toUpperCase() === 'IRONSIGHTS') wp += 20;
           }
-          
+
           item.attributes?.forEach(attr => {
-            if (attr.type === "WP") wp += util.parsePercent(attr.value);
-            if (attr.type === "AS") as += util.parsePercent(attr.value);
+            if (attr.type === 'WP') wp += util.parsePercent(attr.value);
+            if (attr.type === 'AS') as += util.parsePercent(attr.value);
           });
-          
+
           const parts = [];
           if (wp) parts.push(`WP: +${wp}%`);
           if (as) parts.push(`AS: +${as}%`);
-          statValue = parts.join(" & ");
+          statValue = parts.join(' & ');
         } else if (HP_STATS.includes(stat)) {
           let flat = 0, percent = 0;
-          
+
           item.attributes?.forEach(attr => {
             if (attr.type === stat) {
-              if (typeof attr.value === "string" && attr.value.endsWith("%")) {
+              if (typeof attr.value === 'string' && attr.value.endsWith('%')) {
                 percent += util.parsePercent(attr.value);
               } else {
                 flat += (+attr.value || 0);
               }
             }
           });
-          
+
           const parts = [];
           if (flat) parts.push(`+${flat}`);
           if (percent) parts.push(`+${percent}%`);
-          statValue = parts.length ? parts.join(" & ") : "";
+          statValue = parts.length ? parts.join(' & ') : '';
         } else {
           statValue = `+${item.statValue}%`;
         }
-        
+
         html += `
           <li class="${priceClass}">
-            ${item.name} 
+            ${item.name}
             <span style="color:#555;font-size:.94em">
               (${item.cost} cash, ${statValue}${item.character ? ', ' + item.character : ''})
             </span>
           </li>
         `;
       });
-      
+
       html += `</ul></div>`;
     } else {
       html += "<div style='color:#ea4f4f'>No items found for this combination.</div>";
     }
-    
+
     if (result.alternatives?.length > 0) {
       html += `<div class="alt-list"><b>Alternative combinations (same value, different cost):</b><ul>`;
-      
+
       result.alternatives.forEach(combo => {
         html += `<li>
           ${combo.items.map(item => {
             const priceClass = util.getPriceClass(item.cost);
             return `<span class="${priceClass}">${item.name}</span>`;
-          }).join(' + ')} 
+          }).join(' + ')}
           (${combo.cost} cash)
         </li>`;
       });
-      
+
       html += `</ul></div>`;
     }
-    
+
+    return html;
+  },
+
+  renderResults: (result, params) => {
+    const html = ui.renderResultString(result, params);
+    document.getElementById('result').innerHTML = html;
+  },
+
+  renderMultiStatResults: (resultMap, params) => {
+    let html = '';
+    resultMap.order.forEach((stat, idx) => {
+      if (idx > 0) html += '<hr />';
+      html += ui.renderResultString(resultMap.perStat[stat], { ...params, stat });
+    });
     document.getElementById('result').innerHTML = html;
   }
 };


### PR DESCRIPTION
## Summary
- add optional slot selectors in UI to assign different stats per slot
- update UI utilities to populate slot selectors and render results for multiple stats
- add `searchMulti` algorithm and expose via main calculation module
- toggle slot config visibility and handle new calculation mode in `main.js`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6844d24c18f8832b9d8629e5446c903a