### PR TITLE
Add reserve item dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,12 +128,12 @@
       gap: 0.3em;
     }
     
-    .reserve-fields input[type="number"] {
-      width: 75px;
+    .reserve-fields select {
+      width: 100%;
       min-width: 30px;
       padding: 0.32em 0.3em;
       margin: 0;
-      font-size: 0.99em;
+      font-size: 0.92em;
     }
     
     .reserve-fields b {
@@ -207,12 +207,12 @@
       <h1>OW Stadium Build Planner<br><span style="font-size:.86em;font-weight:400;display:block;margin-top:.1em;letter-spacing:.03em;">Max Stat Calculator</span></h1>
       <label>Cash Amount:<input id="cash" type="number" min="0" value="10000"></label>
       <div class="reserve-fields">
-        <b>Reserve cash for 5 items (excluded from calculation):</b>
-        <label>1: <input id="reserve1" type="number" min="0" value="0"></label>
-        <label>2: <input id="reserve2" type="number" min="0" value="0"></label>
-        <label>3: <input id="reserve3" type="number" min="0" value="0"></label>
-        <label>4: <input id="reserve4" type="number" min="0" value="0"></label>
-        <label>5: <input id="reserve5" type="number" min="0" value="0"></label>
+        <b>Reserve items (cost excluded from calculation):</b>
+        <label>1: <select id="reserve1" class="reserve-select"></select></label>
+        <label>2: <select id="reserve2" class="reserve-select"></select></label>
+        <label>3: <select id="reserve3" class="reserve-select"></select></label>
+        <label>4: <select id="reserve4" class="reserve-select"></select></label>
+        <label>5: <select id="reserve5" class="reserve-select"></select></label>
       </div>
       <label>Number of Items:<input id="maxItems" type="number" min="1" max="6" value="5"></label>
       <label>Hero:<select id="hero"></select></label>

--- a/js/main.js
+++ b/js/main.js
@@ -18,8 +18,11 @@ function doCalculate() {
   
   // Get form values
   const cash = parseInt(document.getElementById('cash').value, 10);
-  const reserves = [1, 2, 3, 4, 5].map(i => parseInt(document.getElementById('reserve' + i).value, 10) || 0);
-  const totalReserve = reserves.reduce((a, b) => a + b, 0);
+  const reserveIds = [1, 2, 3, 4, 5].map(i => document.getElementById('reserve' + i).value);
+  const totalReserve = reserveIds.reduce((sum, id) => {
+    const item = state.items.find(it => it.id === id);
+    return sum + (item ? item.cost : 0);
+  }, 0);
   const hero = document.getElementById('hero').value;
   const stat = statSelect.value;
   const baseH = CONSTANTS.HP_STATS.includes(stat) || stat === CONSTANTS.HIT_POINT_STAT 
@@ -87,6 +90,7 @@ async function loadData() {
     
     ui.populateStatOptions(dataFns.getStatTypes(state.items));
     ui.populateHeroes();
+    ui.populateReserveSelectors();
     
     document.getElementById('loading').textContent = "";
   } catch (error) {
@@ -106,6 +110,9 @@ document.getElementById('stat').addEventListener('change', () => {
 });
 document.getElementById('useAllSlots').addEventListener('change', () => {
   document.getElementById('slotConfig').style.display = document.getElementById('useAllSlots').checked ? 'none' : '';
+});
+document.getElementById('hero').addEventListener('change', () => {
+  ui.populateReserveSelectors();
 });
 
 // Initialize the app

--- a/js/ui.js
+++ b/js/ui.js
@@ -58,6 +58,43 @@ export const ui = {
     });
   },
 
+  populateReserveSelectors: () => {
+    const hero = document.getElementById('hero').value;
+    const selects = document.querySelectorAll('.reserve-select');
+    const items = [...state.items];
+
+    items.sort((a, b) => {
+      const aMatch = hero === 'All' ? !a.character : a.character === hero;
+      const bMatch = hero === 'All' ? !b.character : b.character === hero;
+      if (aMatch !== bMatch) return aMatch ? -1 : 1;
+      if (a.cost !== b.cost) return a.cost - b.cost;
+      return a.name.localeCompare(b.name);
+    });
+
+    const getAttrInfo = (attrs = []) =>
+      attrs
+        .filter(at => at.type !== 'description')
+        .map(at => `${at.type} ${at.value}`)
+        .join(', ');
+
+    selects.forEach(sel => {
+      const prev = sel.value;
+      sel.innerHTML = '';
+      const noneOpt = document.createElement('option');
+      noneOpt.value = '';
+      noneOpt.textContent = 'None';
+      sel.appendChild(noneOpt);
+      items.forEach(item => {
+        const op = document.createElement('option');
+        op.value = item.id;
+        const info = getAttrInfo(item.attributes);
+        op.textContent = `${item.cost} - ${item.name}${info ? ' - ' + info : ''}`;
+        sel.appendChild(op);
+      });
+      sel.value = Array.from(sel.options).some(o => o.value === prev) ? prev : '';
+    });
+  },
+
   renderResultString: (result, params) => {
     const { stat, baseH, baseS, baseA, hero } = params;
     const { HIT_POINT_STAT, WEAPON_EFFECT_STAT, HP_STATS, STAT_DISPLAY_NAMES } = CONSTANTS;


### PR DESCRIPTION
## Summary
- turn reserve cash inputs into item dropdowns
- compute reserved cash based on selected item prices
- populate reserve item dropdowns sorted by hero match then price
- adjust layout styles
- repopulate dropdowns when hero changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684504e07964832b8d61fcf531537556